### PR TITLE
update(webhook.go): correct and enhance validation of bucketmount name

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -273,13 +273,11 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {
 				limitDeepestDirName := limitString(bucketDirs[len(bucketDirs)-1], 5)
-				if limitDeepestDirName != "" {
-					filerBucketName = filerBucketName + "-" + limitDeepestDirName
-				}
+				filerBucketName = filerBucketName + "-" + limitDeepestDirName
 			}
 
 			// Ensure the name is unique by appending an integer if necessary
-			filerBucketName = ensureUniqueName(filerBucketName, filerBucketList)
+			filerBucketName = cleanAndSanitizeName(ensureUniqueName(filerBucketName, filerBucketList))
 
 			// Add the unique name to the list
 			filerBucketList = append(filerBucketList, filerBucketName)

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -273,15 +273,14 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {
 				limitDeepestDirName := limitString(cleanAndSanitizeName(bucketDirs[len(bucketDirs)-1]), 5)
-				// Clean and sanitize the filerBucketName after concatenating limitDeepestDirName
-				filerBucketName = filerBucketName + "-" + limitDeepestDirName
+				filerBucketName = cleanAndSanitizeName(filerBucketName + "-" + limitDeepestDirName)
 			}
 
 			// Ensure the name is unique by appending an integer if necessary
 			filerBucketName = ensureUniqueName(filerBucketName, filerBucketList)
 
 			// Add the unique name to the list
-			filerBucketList = append(filerBucketList, filerBucketName)
+			filerBucketList = append(filerBucketList, cleanAndSanitizeName(filerBucketName))
 
 			// Configure the sidecar container
 			// TODO: verify cleaning here

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/barkimedes/go-deepcopy"

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -312,9 +312,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 func cleanAndSanitizeName(name string) string {
 	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
 	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)
-
-	ogName := name
-
+	
 	// Replace any character that does not match the allowed pattern with an empty string
 	name = validNameRegex.ReplaceAllString(name, "")
 
@@ -328,8 +326,6 @@ func cleanAndSanitizeName(name string) string {
 
 	// Remove leading dashes
 	name = strings.TrimLeft(name, "-")
-
-	warningLogger.Printf("Cleaned original name (%s) to clean name (%s)", ogName, name)
 
 	return name
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -321,7 +321,6 @@ func cleanAndSanitizeName(name string) string {
 	// Replace double dashes with a single dash
 	pattern := regexp.MustCompile(`-+`)
 	name = pattern.ReplaceAllString(name, "-")
-	// name = strings.ReplaceAll(name, "--", "-")
 
 	// Remove trailing dashes
 	name = strings.TrimRight(name, "-")

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -284,6 +284,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig.Containers[0].Args = []string{"-c", "/goofys --cheap --endpoint " + s3Url +
 				" --http-timeout 1500s --dir-mode 0777 --file-mode 0777  --debug_fuse --debug_s3 -o allow_other -f " +
 				bucketMount + "/ /tmp; echo sleeping...; sleep infinity"}
+
 			sidecarConfig.Containers[0].Env[0].Value = "fusermount3-proxy-" + filerBucketName + "-" + pod.Namespace + "/fuse-csi-ephemeral.sock"
 			sidecarConfig.Containers[0].Env[1].Value = s3Access
 			sidecarConfig.Containers[0].Env[2].Value = s3Secret

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -244,7 +244,6 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig := tempSidecarConfig.(*Config)
 
 			// Bucket might be a full path with shares, meaning with slashes (path1/path2)
-			// We have to clean this as it will be used in the goofys mount argument
 			bucketMount := string(secret.Data["S3_BUCKET"])
 
 			// S3_URL, S3_ACCESS, and S3_SECRET are essential
@@ -264,8 +263,6 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			bucketDirs := strings.Split(bucketMount, "/")
 
 			// Limit the characters for filer name (max 7 chars) and bucket name (max 5 chars)
-			// cleanAndSanitizeName is called before truncation because we want to guarantee the length
-			// of the limitFilerName is 7 chars and the limitBucketName is 5 chars
 			limitFilerName := limitString(filerName, 7)
 			limitBucketName := limitString(bucketDirs[0], 5)
 			filerBucketName := limitFilerName + "-" + limitBucketName

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -271,6 +271,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 
 			// Clean and sanitize the filerBucketName
 			sanitizedBucketName := cleanAndSanitizeName(filerName)
+			warningLogger.Printf("sanitizedBucketName: %s", sanitizedBucketName)
 
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -288,8 +288,8 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig.Containers[0].Name = filerBucketName
 			sidecarConfig.Containers[0].Args = []string{"-c", "/goofys --cheap --endpoint " + s3Url +
 				" --http-timeout 1500s --dir-mode 0777 --file-mode 0777  --debug_fuse --debug_s3 -o allow_other -f " +
-				bucketMount + "/ /tmp; echo sleeping...; sleep infinity"}
-
+				cleanAndSanitizeName(bucketMount) + "/ /tmp; echo sleeping...; sleep infinity"}
+			// It seems stupid to add cleanAndSanitizeName here but goofys is failing so let's try this.
 			sidecarConfig.Containers[0].Env[0].Value = "fusermount3-proxy-" + filerBucketName + "-" + pod.Namespace + "/fuse-csi-ephemeral.sock"
 			sidecarConfig.Containers[0].Env[1].Value = s3Access
 			sidecarConfig.Containers[0].Env[2].Value = s3Secret

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -312,7 +312,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 func cleanAndSanitizeName(name string) string {
 	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
 	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)
-	
+
 	// Replace any character that does not match the allowed pattern with an empty string
 	name = validNameRegex.ReplaceAllString(name, "")
 

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -334,7 +334,7 @@ func cleanAndSanitizeName(name string) string {
 	// Remove leading dashes
 	name = strings.TrimLeft(name, "-")
 
-	warningLogger.Printf("Cleaned %s to %s", ogName, name)
+	warningLogger.Printf("Cleaned original name (%s) to clean name (%s)", ogName, name)
 
 	return name
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -246,7 +246,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig := tempSidecarConfig.(*Config)
 
 			// Bucket might be a full path with shares, meaning with slashes (path1/path2)
-			bucketMount := string(secret.Data["S3_BUCKET"])
+			bucketMount := cleanAndSanitizeName(string(secret.Data["S3_BUCKET"]))
 
 			// S3_URL, S3_ACCESS, and S3_SECRET are essential
 			s3Url := string(secret.Data["S3_URL"])
@@ -277,7 +277,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			}
 
 			// Ensure the name is unique by appending an integer if necessary
-			filerBucketName = ensureUniqueName(filerBucketName, filerBucketList)
+			filerBucketName = cleanAndSanitizeName(ensureUniqueName(filerBucketName, filerBucketList))
 
 			// Add the unique name to the list
 			filerBucketList = append(filerBucketList, cleanAndSanitizeName(filerBucketName))

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -288,8 +288,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig.Containers[0].Name = filerBucketName
 			sidecarConfig.Containers[0].Args = []string{"-c", "/goofys --cheap --endpoint " + s3Url +
 				" --http-timeout 1500s --dir-mode 0777 --file-mode 0777  --debug_fuse --debug_s3 -o allow_other -f " +
-				cleanAndSanitizeName(bucketMount) + "/ /tmp; echo sleeping...; sleep infinity"}
-			// It seems stupid to add cleanAndSanitizeName here but goofys is failing so let's try this.
+				bucketMount + "/ /tmp; echo sleeping...; sleep infinity"}
 			sidecarConfig.Containers[0].Env[0].Value = "fusermount3-proxy-" + filerBucketName + "-" + pod.Namespace + "/fuse-csi-ephemeral.sock"
 			sidecarConfig.Containers[0].Env[1].Value = s3Access
 			sidecarConfig.Containers[0].Env[2].Value = s3Secret
@@ -319,6 +318,8 @@ func cleanAndSanitizeName(name string) string {
 	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
 	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)
 
+	ogName := name
+
 	// Replace any character that does not match the allowed pattern with an empty string
 	name = validNameRegex.ReplaceAllString(name, "")
 
@@ -332,6 +333,8 @@ func cleanAndSanitizeName(name string) string {
 
 	// Remove leading dashes
 	name = strings.TrimLeft(name, "-")
+
+	warningLogger.Printf("Cleaned %s to %s", ogName, name)
 
 	return name
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -245,7 +245,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 
 			// Bucket might be a full path with shares, meaning with slashes (path1/path2)
 			// We have to clean this as it will be used in the goofys mount argument
-			bucketMount := cleanAndSanitizeName(string(secret.Data["S3_BUCKET"]))
+			bucketMount := string(secret.Data["S3_BUCKET"])
 
 			// S3_URL, S3_ACCESS, and S3_SECRET are essential
 			s3Url := string(secret.Data["S3_URL"])

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -268,7 +268,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			filerBucketName := limitFilerName + "-" + limitBucketName
 
 			// Clean and sanitize the filerBucketName
-			filerBucketName = cleanAndSanitizeName(filerBucketName)
+			sanitizedBucketName := cleanAndSanitizeName(filerName)
 
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {
@@ -286,7 +286,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			sidecarConfig.Containers[0].Name = filerBucketName
 			sidecarConfig.Containers[0].Args = []string{"-c", "/goofys --cheap --endpoint " + s3Url +
 				" --http-timeout 1500s --dir-mode 0777 --file-mode 0777  --debug_fuse --debug_s3 -o allow_other -f " +
-				bucketMount + "/ /tmp; echo sleeping...; sleep infinity"}
+				sanitizedBucketName + "/ /tmp; echo sleeping...; sleep infinity"}
 
 			sidecarConfig.Containers[0].Env[0].Value = "fusermount3-proxy-" + filerBucketName + "-" + pod.Namespace + "/fuse-csi-ephemeral.sock"
 			sidecarConfig.Containers[0].Env[1].Value = s3Access

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -263,11 +263,9 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			bucketDirs := strings.Split(bucketMount, "/")
 
 			// Limit the characters for filer name (max 7 chars) and bucket name (max 5 chars)
-			// cleanAndSanitizeName is called before truncation because we want to guarantee the length
-			// of the limitFilerName is 7 chars and the limitBucketName is 5 chars
-			limitFilerName := limitString(cleanAndSanitizeName(filerName), 7)
-			limitBucketName := limitString(cleanAndSanitizeName(bucketDirs[0]), 5)
-			filerBucketName := limitFilerName + "-" + limitBucketName
+			limitFilerName := limitString(filerName, 7)
+			limitBucketName := limitString(bucketDirs[0], 5)
+			filerBucketName := cleanAndSanitizeName(limitFilerName + "-" + limitBucketName)
 
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -276,9 +276,6 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 				filerBucketName = filerBucketName + "-" + limitDeepestDirName
 			}
 
-			// Ensure the name is unique by appending an integer if necessary
-			filerBucketName = cleanAndSanitizeName(ensureUniqueName(filerBucketName, filerBucketList))
-
 			// Add the unique name to the list
 			filerBucketList = append(filerBucketList, filerBucketName)
 
@@ -335,21 +332,6 @@ func cleanAndSanitizeName(name string) string {
 	warningLogger.Printf("Cleaned original name (%s) to clean name (%s)", ogName, name)
 
 	return name
-}
-
-// Function to ensure name uniqueness by appending an integer if the name already exists
-func ensureUniqueName(baseName string, existingNames []string) string {
-	// Check if the name is already in the list of existing names
-	if slices.Contains(existingNames, baseName) {
-		// Append an integer to make the name unique
-		for i := 1; ; i++ {
-			newName := fmt.Sprintf("%s-%d", baseName, i)
-			if !slices.Contains(existingNames, newName) {
-				return newName
-			}
-		}
-	}
-	return baseName
 }
 
 // Helper function to limit string length

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -313,7 +313,6 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 	return json.Marshal(patch)
 }
 
-// Function to clean and sanitize the name by removing illegal characters
 func cleanAndSanitizeName(name string) string {
 	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
 	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)
@@ -322,13 +321,19 @@ func cleanAndSanitizeName(name string) string {
 	name = validNameRegex.ReplaceAllString(name, "")
 
 	// Replace double dashes with a single dash
-	name = strings.ReplaceAll(name, "--", "-")
+	pattern := regexp.MustCompile(`-+`)
+	name = pattern.ReplaceAllString(name, "-")
+	// name = strings.ReplaceAll(name, "--", "-")
 
 	// Remove trailing dashes
 	name = strings.TrimRight(name, "-")
 
+	// Remove leading dashes
+	name = strings.TrimLeft(name, "-")
+
 	return name
 }
+
 
 // Function to ensure name uniqueness by appending an integer if the name already exists
 func ensureUniqueName(baseName string, existingNames []string) string {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -13,9 +13,11 @@ import (
 	"strings"
 
 	"github.com/barkimedes/go-deepcopy"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -333,7 +335,6 @@ func cleanAndSanitizeName(name string) string {
 
 	return name
 }
-
 
 // Function to ensure name uniqueness by appending an integer if the name already exists
 func ensureUniqueName(baseName string, existingNames []string) string {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -310,6 +310,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 	return json.Marshal(patch)
 }
 
+// Function to clean and sanitize the name by removing illegal characters
 func cleanAndSanitizeName(name string) string {
 	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
 	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -276,7 +276,8 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, annotations map
 			// Append the deepest directory name if available
 			if len(bucketDirs) >= 2 {
 				limitDeepestDirName := limitString(bucketDirs[len(bucketDirs)-1], 5)
-				filerBucketName = filerBucketName + "-" + limitDeepestDirName
+				// Clean and sanitize the filerBucketName
+				filerBucketName = cleanAndSanitizeName(filerBucketName + "-" + limitDeepestDirName)
 			}
 
 			// Ensure the name is unique by appending an integer if necessary


### PR DESCRIPTION
I have added a function called `cleanAndSanitizeName` which cleans the `bucketMount` variable and the `filerBucketName`. This function removes illegal characters and cleans up multi dashes, leading dashes and trailing dashes.

The function also includes some logging so we can see in the logs what the original name was and what it was cleaned to.

``` go
func cleanAndSanitizeName(name string) string {
	// Define the allowed regex pattern: lowercase letters, numbers, and dashes
	validNameRegex := regexp.MustCompile(`[^a-z0-9-]`)

	// Replace any character that does not match the allowed pattern with an empty string
	name = validNameRegex.ReplaceAllString(name, "")

	// Replace double dashes with a single dash
	pattern := regexp.MustCompile(`-+`)
	name = pattern.ReplaceAllString(name, "-")

	// Remove trailing dashes
	name = strings.TrimRight(name, "-")

	// Remove leading dashes
	name = strings.TrimLeft(name, "-")

	return name
}

```