### PR TITLE
chore(annotation): do not clobber existing annotations

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -159,13 +159,13 @@ func updateAnnotation(target map[string]string) (patch []patchOperation) {
 	if target == nil || target[admissionWebhookAnnotationInjectKey] == "" {
 		patch = append(patch, patchOperation{
 			Op:    "add",
-			Path:  "/metadata/annotations/" + admissionWebhookAnnotationInjectKey,
+			Path:  "/metadata/annotations/filer-injector-webhook.das-zone.statcan~1inject",
 			Value: "injected",
 		})
 	} else {
 		patch = append(patch, patchOperation{
 			Op:    "replace",
-			Path:  "/metadata/annotations/" + admissionWebhookAnnotationInjectKey,
+			Path:  "/metadata/annotations/filer-injector-webhook.das-zone.statcan~1inject",
 			Value: "injected",
 		})
 	}

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -159,7 +159,7 @@ func updateAnnotation(target map[string]string) (patch []patchOperation) {
 	if target == nil || target[admissionWebhookAnnotationInjectKey] == "" {
 		patch = append(patch, patchOperation{
 			Op:    "add",
-			Path:  "/metadata/annotations",
+			Path:  "/metadata/annotations/" + admissionWebhookAnnotationInjectKey,
 			Value: "injected",
 		})
 	} else {


### PR DESCRIPTION
For [BTIS-874](https://jirab.statcan.ca/browse/BTIS-874)
related to https://github.com/StatCan/kubeflow/pull/246

Previously the annotation was not being propagated, this screenshot is from the kerberos sidecar injector but it uses the same logic so we will need to port it there as well. 

Also removed an extraneous variable / annotation and combined it.
Using: `61e89f5b03d393bcca846ed71dbfcb72a82d172e`