### PR TITLE
fix(webhook.go): Consider 0th index

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -116,7 +116,7 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 // addContainerTracked adds containers using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
 func addContainerTracked(alreadyAdded bool, added []corev1.Container, basePath string) (patch []patchOperation) {
-	first := alreadyAdded
+	first := !alreadyAdded
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -139,7 +139,7 @@ func addContainerTracked(alreadyAdded bool, added []corev1.Container, basePath s
 // addVolumeTracked adds volumes using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
 func addVolumeTracked(alreadyAdded bool, added []corev1.Volume, basePath string) (patch []patchOperation) {
-	first := alreadyAdded
+	first := !alreadyAdded
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -248,11 +248,12 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 		isFirstVol = false
 	}
 
-	// Track how many containers and volumes we've added to the patch
-	// Start with the count of what already exists in the pod
-	containersAdded := len(pod.Spec.InitContainers) > 0
-	volumesAdded := len(pod.Spec.Volumes) > 0
-
+	// Track whether we have already added a container to know the correct path for the patch (first addition is different than subsequent additions)
+	isFirstContainer := true
+	// We don't want to overwrite any containers
+	if len(pod.Spec.Containers) > 0 {
+		isFirstContainer = false
+	}
 	// shareList.Data is a map[string]string
 	// https://goplay.tools/snippet/zUiIt23ZYVK
 	var shareList []string
@@ -319,11 +320,10 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 
 			// Add container to initContainers and volume to the patch
 			// Pass bools to track first addition and handle path change
-			patch = append(patch, addContainerTracked(containersAdded, sidecarConfig.Containers, "/spec/initContainers")...)
-			containersAdded = true
+			patch = append(patch, addContainerTracked(isFirstContainer, sidecarConfig.Containers, "/spec/initContainers")...)
+			isFirstContainer = false
 
-			patch = append(patch, addVolumeTracked(volumesAdded, sidecarConfig.Volumes, "/spec/volumes")...)
-			volumesAdded = true
+			patch = append(patch, addVolumeTracked(isFirstVol, sidecarConfig.Volumes, "/spec/volumes")...)
 
 			patch = append(patch, updateAnnotation(pod.Annotations)...)
 			patch = append(patch, updateWorkingVolumeMounts(pod.Spec.Containers, csiEphemeralVolumeountName, bucketMount, svmName, isFirstVol)...)

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -258,7 +258,8 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 			Path:  "/spec/initContainers",
 			Value: []corev1.Container{},
 		})
-	} else if len(pod.Spec.InitContainers) > 0 {
+	}
+	if len(pod.Spec.InitContainers) > 0 {
 		isFirstInitContainer = false
 	}
 

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -249,10 +249,10 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 	}
 
 	// Track whether we have already added a container to know the correct path for the patch (first addition is different than subsequent additions)
-	isFirstContainer := true
+	isFirstInitContainer := true
 	// We don't want to overwrite any containers
-	if len(pod.Spec.Containers) > 0 {
-		isFirstContainer = false
+	if len(pod.Spec.InitContainers) > 0 {
+		isFirstInitContainer = false
 	}
 	// shareList.Data is a map[string]string
 	// https://goplay.tools/snippet/zUiIt23ZYVK
@@ -320,8 +320,8 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 
 			// Add container to initContainers and volume to the patch
 			// Pass bools to track first addition and handle path change
-			patch = append(patch, addContainerTracked(isFirstContainer, sidecarConfig.Containers, "/spec/initContainers")...)
-			isFirstContainer = false
+			patch = append(patch, addContainerTracked(isFirstInitContainer, sidecarConfig.Containers, "/spec/initContainers")...)
+			isFirstInitContainer = false
 
 			patch = append(patch, addVolumeTracked(isFirstVol, sidecarConfig.Volumes, "/spec/volumes")...)
 

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -128,8 +128,8 @@ func addContainer(added []corev1.Container, basePath string) (patch []patchOpera
 
 // addVolumeTracked adds volumes using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addVolumeTracked(isFirst bool, added []corev1.Volume, basePath string) (patch []patchOperation) {
-	first := isFirst
+func addVolumeTracked(target, added []corev1.Volume, basePath string) (patch []patchOperation) {
+	first := len(target) == 0
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -319,7 +319,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 			// Pass bools to track first addition and handle path change
 			patch = append(patch, addContainer(sidecarConfig.Containers, "/spec/initContainers")...)
 
-			patch = append(patch, addVolumeTracked(isFirstVol, sidecarConfig.Volumes, "/spec/volumes")...)
+			patch = append(patch, addVolumeTracked(pod.Spec.Volumes, sidecarConfig.Volumes, "/spec/volumes")...)
 
 			patch = append(patch, updateAnnotation(pod.Annotations)...)
 			patch = append(patch, updateWorkingVolumeMounts(pod.Spec.Containers, csiEphemeralVolumeountName, bucketMount, svmName, isFirstVol)...)

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -117,6 +117,7 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 // This fixes the bug where multiple loop iterations would overwrite previous additions
 func addContainerTracked(added []corev1.Container, basePath string) (patch []patchOperation) {
 	for _, add := range added {
+		klog.Infof("container patch with name: %s", add.Name)
 		patch = append(patch, patchOperation{
 			Op:    "add",
 			Path:  basePath + "/-",
@@ -239,7 +240,6 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 	}
 
 	// Track whether we have already added a container to know the correct path for the patch (first addition is different than subsequent additions)
-	isFirstInitContainer := true
 	// We don't want to overwrite any containers
 	// If the field is missing entirely, create it as an empty array first.
 	if pod.Spec.InitContainers == nil {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -113,10 +113,10 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 	return required
 }
 
-// addContainerTracked adds containers using a counter to determine if it's the first addition
+// addContainerTracked adds containers using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addContainerTracked(alreadyAdded int, added []corev1.Container, basePath string) (patch []patchOperation) {
-	first := alreadyAdded == 0
+func addContainerTracked(alreadyAdded bool, added []corev1.Container, basePath string) (patch []patchOperation) {
+	first := alreadyAdded
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -136,10 +136,10 @@ func addContainerTracked(alreadyAdded int, added []corev1.Container, basePath st
 	return patch
 }
 
-// addVolumeTracked adds volumes using a counter to determine if it's the first addition
+// addVolumeTracked adds volumes using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addVolumeTracked(alreadyAdded int, added []corev1.Volume, basePath string) (patch []patchOperation) {
-	first := alreadyAdded == 0
+func addVolumeTracked(alreadyAdded bool, added []corev1.Volume, basePath string) (patch []patchOperation) {
+	first := alreadyAdded
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -250,8 +250,8 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 
 	// Track how many containers and volumes we've added to the patch
 	// Start with the count of what already exists in the pod
-	containersAdded := len(pod.Spec.InitContainers)
-	volumesAdded := len(pod.Spec.Volumes)
+	containersAdded := len(pod.Spec.InitContainers) > 0
+	volumesAdded := len(pod.Spec.Volumes) > 0
 
 	// shareList.Data is a map[string]string
 	// https://goplay.tools/snippet/zUiIt23ZYVK
@@ -262,8 +262,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 		secret, err := clientset.CoreV1().Secrets(pod.Namespace).Get(context.Background(),
 			svmSecretName, metav1.GetOptions{})
 		if k8serrors.IsNotFound(err) {
-			klog.Infof("Error, secret for svm:" + svmName + " was not found for ns:" + pod.Namespace +
-				" so mounting will be skipped")
+			klog.Infof("Error, secret for svm: %s was not found for ns: %s so mounting will be skipped", svmName, pod.Namespace)
 			continue
 		}
 		s3Url := string(svmInfoMap[svmName].Url)
@@ -272,8 +271,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 		// Unmarshal to get list of wanted shares to mount
 		err = json.Unmarshal([]byte(svmShareList.Data[svmName]), &shareList)
 		if err != nil {
-			klog.Infof("Error unmarshalling the share list for svm:" + svmName +
-				" for ns:" + pod.Namespace + " so mounting will be skipped")
+			klog.Infof("Error unmarshalling the share list for svm: %s for ns: %s so mounting will be skipped", svmName, pod.Namespace)
 			continue
 		}
 		// must set ACCESS and SECRET keys as well as svm url in the patch
@@ -320,13 +318,12 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 			sidecarConfig.Volumes[1].CSI.VolumeAttributes["fdPassingEmptyDirName"] = fdPassingvolumeMountName
 
 			// Add container to initContainers and volume to the patch
-			// Pass containersAdded to determine if this is the first container
+			// Pass bools to track first addition and handle path change
 			patch = append(patch, addContainerTracked(containersAdded, sidecarConfig.Containers, "/spec/initContainers")...)
-			containersAdded++
+			containersAdded = true
 
-			// Add volumes - pass volumesAdded count
 			patch = append(patch, addVolumeTracked(volumesAdded, sidecarConfig.Volumes, "/spec/volumes")...)
-			volumesAdded += 2 // We add 2 volumes per iteration (fuse-fd-passing and fuse-csi-ephemeral)
+			volumesAdded = true
 
 			patch = append(patch, updateAnnotation(pod.Annotations)...)
 			patch = append(patch, updateWorkingVolumeMounts(pod.Spec.Containers, csiEphemeralVolumeountName, bucketMount, svmName, isFirstVol)...)

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -115,22 +115,12 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 
 // addContainerTracked adds containers using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addContainerTracked(isFirst bool, added []corev1.Container, basePath string) (patch []patchOperation) {
-	first := isFirst
-	var value interface{}
+func addContainerTracked(added []corev1.Container, basePath string) (patch []patchOperation) {
 	for _, add := range added {
-		value = add
-		path := basePath
-		if first {
-			first = false
-			value = []corev1.Container{add}
-		} else {
-			path = path + "/-"
-		}
 		patch = append(patch, patchOperation{
 			Op:    "add",
-			Path:  path,
-			Value: value,
+			Path:  basePath + "/-",
+			Value: add,
 		})
 	}
 	return patch
@@ -253,14 +243,12 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 	// We don't want to overwrite any containers
 	// If the field is missing entirely, create it as an empty array first.
 	if pod.Spec.InitContainers == nil {
+		klog.Infof("Patch appended")
 		patch = append(patch, patchOperation{
 			Op:    "add",
 			Path:  "/spec/initContainers",
 			Value: []corev1.Container{},
 		})
-	}
-	if len(pod.Spec.InitContainers) > 0 {
-		isFirstInitContainer = false
 	}
 
 	// shareList.Data is a map[string]string
@@ -329,8 +317,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 
 			// Add container to initContainers and volume to the patch
 			// Pass bools to track first addition and handle path change
-			patch = append(patch, addContainerTracked(isFirstInitContainer, sidecarConfig.Containers, "/spec/initContainers")...)
-			isFirstInitContainer = false
+			patch = append(patch, addContainerTracked(sidecarConfig.Containers, "/spec/initContainers")...)
 
 			patch = append(patch, addVolumeTracked(isFirstVol, sidecarConfig.Volumes, "/spec/volumes")...)
 

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -115,8 +115,8 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 
 // addContainerTracked adds containers using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addContainerTracked(alreadyAdded bool, added []corev1.Container, basePath string) (patch []patchOperation) {
-	first := !alreadyAdded
+func addContainerTracked(isFirst bool, added []corev1.Container, basePath string) (patch []patchOperation) {
+	first := isFirst
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -138,8 +138,8 @@ func addContainerTracked(alreadyAdded bool, added []corev1.Container, basePath s
 
 // addVolumeTracked adds volumes using a boolean to determine if it's the first addition
 // This fixes the bug where multiple loop iterations would overwrite previous additions
-func addVolumeTracked(alreadyAdded bool, added []corev1.Volume, basePath string) (patch []patchOperation) {
-	first := !alreadyAdded
+func addVolumeTracked(isFirst bool, added []corev1.Volume, basePath string) (patch []patchOperation) {
+	first := isFirst
 	var value interface{}
 	for _, add := range added {
 		value = add

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -251,9 +251,17 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 	// Track whether we have already added a container to know the correct path for the patch (first addition is different than subsequent additions)
 	isFirstInitContainer := true
 	// We don't want to overwrite any containers
-	if len(pod.Spec.InitContainers) > 0 {
+	// If the field is missing entirely, create it as an empty array first.
+	if pod.Spec.InitContainers == nil {
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  "/spec/initContainers",
+			Value: []corev1.Container{},
+		})
+	} else if len(pod.Spec.InitContainers) > 0 {
 		isFirstInitContainer = false
 	}
+
 	// shareList.Data is a map[string]string
 	// https://goplay.tools/snippet/zUiIt23ZYVK
 	var shareList []string

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -113,8 +113,10 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 	return required
 }
 
-func addContainer(target, added []corev1.Container, basePath string) (patch []patchOperation) {
-	first := len(target) == 0
+// addContainerTracked adds containers using a counter to determine if it's the first addition
+// This fixes the bug where multiple loop iterations would overwrite previous additions
+func addContainerTracked(alreadyAdded int, added []corev1.Container, basePath string) (patch []patchOperation) {
+	first := alreadyAdded == 0
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -134,8 +136,10 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []pa
 	return patch
 }
 
-func addVolume(target, added []corev1.Volume, basePath string) (patch []patchOperation) {
-	first := len(target) == 0
+// addVolumeTracked adds volumes using a counter to determine if it's the first addition
+// This fixes the bug where multiple loop iterations would overwrite previous additions
+func addVolumeTracked(alreadyAdded int, added []corev1.Volume, basePath string) (patch []patchOperation) {
+	first := alreadyAdded == 0
 	var value interface{}
 	for _, add := range added {
 		value = add
@@ -244,6 +248,11 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 		isFirstVol = false
 	}
 
+	// Track how many containers and volumes we've added to the patch
+	// Start with the count of what already exists in the pod
+	containersAdded := len(pod.Spec.InitContainers)
+	volumesAdded := len(pod.Spec.Volumes)
+
 	// shareList.Data is a map[string]string
 	// https://goplay.tools/snippet/zUiIt23ZYVK
 	var shareList []string
@@ -311,9 +320,14 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 			sidecarConfig.Volumes[1].CSI.VolumeAttributes["fdPassingEmptyDirName"] = fdPassingvolumeMountName
 
 			// Add container to initContainers and volume to the patch
-			patch = append(patch, addContainer(pod.Spec.InitContainers, sidecarConfig.Containers, "/spec/initContainers")...)
-			// Add restartPolicy: Always to allow sidecar to terminate when main container completes
-			patch = append(patch, addVolume(pod.Spec.Volumes, sidecarConfig.Volumes, "/spec/volumes")...)
+			// Pass containersAdded to determine if this is the first container
+			patch = append(patch, addContainerTracked(containersAdded, sidecarConfig.Containers, "/spec/initContainers")...)
+			containersAdded++
+
+			// Add volumes - pass volumesAdded count
+			patch = append(patch, addVolumeTracked(volumesAdded, sidecarConfig.Volumes, "/spec/volumes")...)
+			volumesAdded += 2 // We add 2 volumes per iteration (fuse-fd-passing and fuse-csi-ephemeral)
+
 			patch = append(patch, updateAnnotation(pod.Annotations)...)
 			patch = append(patch, updateWorkingVolumeMounts(pod.Spec.Containers, csiEphemeralVolumeountName, bucketMount, svmName, isFirstVol)...)
 			// Add the environment variables

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -113,9 +113,8 @@ func mutationRequired(metadata *metav1.ObjectMeta) bool {
 	return required
 }
 
-// addContainerTracked adds containers using a boolean to determine if it's the first addition
-// This fixes the bug where multiple loop iterations would overwrite previous additions
-func addContainerTracked(added []corev1.Container, basePath string) (patch []patchOperation) {
+// addContainers simply never add to an empty initContainers array
+func addContainer(added []corev1.Container, basePath string) (patch []patchOperation) {
 	for _, add := range added {
 		klog.Infof("container patch with name: %s", add.Name)
 		patch = append(patch, patchOperation{
@@ -239,8 +238,9 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 		isFirstVol = false
 	}
 
-	// Track whether we have already added a container to know the correct path for the patch (first addition is different than subsequent additions)
 	// We don't want to overwrite any containers
+	// We always want to append, so no need to change the isFirst for this one,
+	// but we do want to check if initContainers exists first because if it doesn't then we need to add it before we can append to it
 	// If the field is missing entirely, create it as an empty array first.
 	if pod.Spec.InitContainers == nil {
 		klog.Infof("Patch appended")
@@ -317,7 +317,7 @@ func createPatch(pod *corev1.Pod, sidecarConfigTemplate *Config, clientset *kube
 
 			// Add container to initContainers and volume to the patch
 			// Pass bools to track first addition and handle path change
-			patch = append(patch, addContainerTracked(sidecarConfig.Containers, "/spec/initContainers")...)
+			patch = append(patch, addContainer(sidecarConfig.Containers, "/spec/initContainers")...)
 
 			patch = append(patch, addVolumeTracked(isFirstVol, sidecarConfig.Volumes, "/spec/volumes")...)
 

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   sidecarconfig.json: |
     {
-    "containers": [
+    "initContainers": [
         {
             "name": "filer-connection-x",
             "image": "artifactory.cloud.statcan.ca/das-aaw-docker/mfcp-proxy-goofys-multi-inc:5gb",

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   sidecarconfig.json: |
     {
-    "initContainers": [
+    "containers": [
         {
             "name": "filer-connection-x",
             "image": "artifactory.cloud.statcan.ca/das-aaw-docker/mfcp-proxy-goofys-multi-inc:5gb",


### PR DESCRIPTION
# Webhook Bug Fix: Multiple Sidecars Not Being Injected

## Problem Description

When deploying with **multiple volumes/shares** to mount, only the **last** injected sidecar initContainer appeared in the mutated Pod.

## Root Cause

### Root Cause A — Repeated “first add” overwrote earlier additions

The original injection logic called helpers like this on every loop iteration:

```go
// BUGGY CODE - called in each loop iteration
patch = append(patch, addContainer(pod.Spec.InitContainers, sidecarConfig.Containers, "/spec/initContainers")...)
```

The helper functions determine “first vs append” like this:

```go
first := len(target) == 0
```

**The problem:** Each loop iteration passed the **original, unchanged** `pod.Spec.InitContainers`  Those slices were never updated during patch construction, so `len(target)` stayed `0` every time.

That caused patches like:

```json
[
  {"op": "add", "path": "/spec/initContainers", "value": [container1]},
  {"op": "add", "path": "/spec/initContainers", "value": [container2]},
  {"op": "add", "path": "/spec/initContainers", "value": [container3]}
]
```

In JSON Patch, `op: add` on an existing field path effectively **replaces** the value, so only the **last** one survived.

### Root Cause B — Appending to an array that doesn’t exist

After switching to append semantics:

```json
{"op":"add","path":"/spec/initContainers/-","value":{...}}
```

Kubernetes rejects this when `/spec/initContainers` is **missing** (not present at all), producing:

```
doc is missing path: "/spec/initContainers/-"
```

This happens commonly for Pods created that don’t define `initContainers` upfront.

## Solution

### Step 1 — Ensure the arrays exist once (`initContainers`)

Before appending any entries, the webhook ensures these fields exist:

* If `spec.initContainers` is missing, add it as an empty array `[]`

Example patches:

```json
{"op":"add","path":"/spec/initContainers","value":[]}
```

### Step 2 — Always append with `/-`

Once the arrays exist, every injected initContainer is appended using `/-`:

```json
{"op":"add","path":"/spec/initContainers/-","value":{...}}
```

This removes the need to track “first vs subsequent” across loop iterations and prevents overwrites.

## Correct Behavior Now

With `N` shares, the webhook generates:

* At most **1** patch to create `/spec/initContainers` (only if missing)
* **N** patches to append initContainers

Example (simplified):

```json
[
  {"op":"add","path":"/spec/initContainers","value":[]},
  {"op":"add","path":"/spec/initContainers/-","value":container1},
  {"op":"add","path":"/spec/initContainers/-","value":container2},
]
```

## Files Changed

* `webhook.go`

  * Added “ensure array exists” logic for:

    * `/spec/initContainers`
  * Updated injection to append using `/-` consistently
  * Removed reliance on `len(target) == 0` for correctness across loop iterations

## Testing Recommendations

1. Create a ConfigMap with **multiple shares** for a single SVM
2. Create a ConfigMap with **multiple SVMs**, each with multiple shares
3. Verify the mutated pod contains **all** expected initContainers and volumes
4. Check webhook logs to confirm:

   * `add /spec/initContainers []` appears only when missing
   * subsequent initContainer ops use `/spec/initContainers/-`
5. Verify all volumes mount correctly in the running pod

## Additional Notes

* Each share injects:

  * **1 initContainer**
  * **2 volumes** (fuse-fd-passing + fuse-csi-ephemeral)
* Ensuring arrays exist prevents:

  * overwrite-by-repeated-add on `/spec/initContainers` 
  * missing-path failures when appending with `/-`
